### PR TITLE
강은호 푼 문제(COW 포함)

### DIFF
--- a/Eunho/240413/20366(BinarySearch).cpp
+++ b/Eunho/240413/20366(BinarySearch).cpp
@@ -1,0 +1,45 @@
+﻿#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int N;
+int ball[600];
+
+int main()
+{
+    ios_base::sync_with_stdio(0);cin.tie(0);cout.tie(0);
+    cin >> N;
+    for (int i = 0; i < N; ++i)
+    {
+        cin >> ball[i];
+    }
+    sort(ball, ball + N);
+    int result = 9876543210;
+    for (int i = 0; i < N; ++i)
+    {
+        for (int j = i + 1; j < N; ++j)
+        {
+            for (int k = j + 1; k < N; ++k)
+            {
+                int lo = k + 1, hi = N;
+                int mid;
+                int target = -ball[i] + ball[j] + ball[k];
+                while (lo <= hi)
+                {
+                    mid = (lo + hi) / 2;
+                    result = min(result, abs(target - ball[mid]));
+                    if (target > ball[mid])
+                    {
+                        lo = mid + 1;
+                    }
+                    else
+                    {
+                        hi = mid - 1;
+                    }
+                }
+            }
+        }
+    }
+    cout << result;
+    return 0;
+}

--- a/Eunho/240413/20366.cpp
+++ b/Eunho/240413/20366.cpp
@@ -1,0 +1,54 @@
+﻿#include <iostream>
+#include <algorithm>
+using namespace std;
+
+int N;
+int ball[600];
+int result = 9876543210;
+
+void MakeSnowman(int start, int end)
+{
+    int i = start + 1;
+    int j = end - 1;
+    while (i < j)
+    {
+        int temp = ball[start] + ball[end] - ball[i] - ball[j];
+        result = min(result, abs(temp));
+        if (temp > 0)
+        {
+            i++;
+        }
+        else
+        {
+            j--;
+        }
+    }
+}
+
+
+int main()
+{
+    ios_base::sync_with_stdio(0);cin.tie(0);cout.tie(0);
+    cin >> N;
+    for (int i = 0; i < N; ++i)
+    {
+        cin >> ball[i];
+    }
+    sort(ball, ball + N);
+    for (int i = 0; i < N; ++i)
+    {
+        for (int j = i + 1; j < N; ++j)
+        {
+            MakeSnowman(i, j);
+        }
+    }
+    cout << result;
+    return 0;
+}
+
+/*
+* 차이가 최소인 조합 두개를 만드는 문제.
+* 브루트포스 사용 시 O(nC4)로 N=600에서 시간초과가 발생한다.
+* 미리 눈사람 하나를 만들고, 나머지 하나는 투 포인터로 양 끝에서 세면서 
+* 차이가 작은 눈사람을 하나 더 만드는 작업을 진행한다.
+*/


### PR DESCRIPTION
![image](https://github.com/Barone12/CodingTestGenius/assets/37584805/7ea8f9dc-2693-4ae4-965f-47d721d5a5f5)

이번 COW 문제는 모르겠어서 [풀이](https://www.acmicpc.net/board/view/114349) 참고해서 풀었습니다.
처음엔 이진 탐색으로 해보려 했는데 잘 안풀려서 결국 투 포인터로 바꾸어서 풀었습니다.
왜 안되나 다시 봤더니 이분 탐색 부등호 방향이 바꼈더군요...
그래서 두 풀이 모두 올려뒀습니다. 시간은 투 포인터 쪽이 더 빠르네요.
두 풀이 모두 순회 횟수를 줄이는 방향으로 접근하는 것입니다.
투 포인터는 O(N^3), 이분 탐색은 O(N^3lnN)의 시간복잡도를 가집니다.

오류 지적이나 피드백 언제든 환영합니다.