### PR TITLE
Add | [240516]1456_거의소수.cpp

### DIFF
--- a/Donghee/[240516]1456_거의소수.cpp
+++ b/Donghee/[240516]1456_거의소수.cpp
@@ -1,0 +1,37 @@
+#include <iostream>
+using namespace std;
+
+const int SIZE = 10000001;
+int isPrime[SIZE];
+
+int main() {
+  long long A, B;
+  cin >> A >> B;
+
+  for (int idx = 2; idx < SIZE; idx++) {
+    isPrime[idx] = 1;
+  }
+
+  for (long long num = 2; num * num < SIZE; num++) {
+    if (!isPrime[num]) continue;
+    for (long long multiple = 2 * num; multiple < SIZE; multiple += num) {
+      isPrime[multiple] = 0;
+    }
+  }
+
+  int aUnderCount = 0;
+  int bUnderCount = 0;
+  for (long long num = 2; num * num <= B; num++) 
+  {
+    if (!isPrime[num]) continue;
+    // almostPrime <= B; 로 조건을 작성하면 마지막 분기에서 오버플로우 발생
+    for (long long almostPrime = num; almostPrime <= B / num; almostPrime *= num) 
+    {
+      if (almostPrime * num < A) aUnderCount++;
+      bUnderCount++;
+    }
+  }
+
+  cout << bUnderCount - aUnderCount;
+}
+


### PR DESCRIPTION
- BOJ 1456_거의소수
평범한 소수문제인줄 알았는데.. 범위가 너무 커 변수를 long long으로 잡고도 long long의 오버플로우를 고려해야하는 문제였다. 거의소수를 판단하는 for문에서 조건문을 본래 소수로 나눠 오버플로우를 방지하고, for문 안에서 소수를 한번 더 곱해주어 거의소수를 판단했다.